### PR TITLE
AuditingFields 수정 시간 필드 분리 PR입니다.

### DIFF
--- a/src/main/java/com/hansung/hansungcommunity/entity/AuditingFields.java
+++ b/src/main/java/com/hansung/hansungcommunity/entity/AuditingFields.java
@@ -1,15 +1,10 @@
 package com.hansung.hansungcommunity.entity;
 
 
-import com.hansung.hansungcommunity.config.JpaAuditingConfig;
 import lombok.Getter;
 import lombok.ToString;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.Column;
@@ -28,14 +23,5 @@ public abstract class AuditingFields {
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
-
-    //수정 일자
-    @DateTimeFormat(iso= DateTimeFormat.ISO.DATE_TIME)
-    @LastModifiedDate
-    @Column
-    private LocalDateTime modifiedAt;
-
-
-
 
 }

--- a/src/main/java/com/hansung/hansungcommunity/entity/FreeBoard.java
+++ b/src/main/java/com/hansung/hansungcommunity/entity/FreeBoard.java
@@ -13,7 +13,7 @@ import javax.validation.constraints.NotNull;
 @Getter
 @Setter
 @Entity
-public class FreeBoard extends AuditingFields {
+public class FreeBoard extends ModifiedEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "free_board_id")
@@ -60,6 +60,8 @@ public class FreeBoard extends AuditingFields {
 
         if (dto.getContent() != null)
             this.content = dto.getContent();
+
+        modified();
     }
 
     // 조회수 증가 메소드

--- a/src/main/java/com/hansung/hansungcommunity/entity/ModifiedEntity.java
+++ b/src/main/java/com/hansung/hansungcommunity/entity/ModifiedEntity.java
@@ -1,0 +1,29 @@
+package com.hansung.hansungcommunity.entity;
+
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.Column;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+/**
+ * 수정 시간(공통 필드)를 담고 있는 Entity
+ * 현재, FreeBoard, QnaBoard 에만 적용함
+ * 추후 댓글에도 활용 가능
+ */
+
+@MappedSuperclass
+@Getter
+public class ModifiedEntity extends AuditingFields {
+
+    // 수정 일자
+    @DateTimeFormat(iso= DateTimeFormat.ISO.DATE_TIME)
+    @Column
+    private LocalDateTime modifiedAt;
+
+    public void modified() {
+        this.modifiedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/hansung/hansungcommunity/entity/QnaBoard.java
+++ b/src/main/java/com/hansung/hansungcommunity/entity/QnaBoard.java
@@ -15,41 +15,45 @@ import java.util.Objects;
 @Getter
 @ToString(callSuper = true)
 @Entity
-public class QnaBoard extends AuditingFields{
+public class QnaBoard extends ModifiedEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "qna_board_id")
     private Long id;
 
-    @NotNull private String title;
-    @NotNull @Lob private String content;  //TODO: length 설정하기
+    @NotNull
+    private String title;
+    @NotNull
+    @Lob
+    private String content;  //TODO: length 설정하기
     //@NotNull
     private int point;
-    @Column private String tag;
+    @Column
+    private String tag;
 
-    @ColumnDefault(value = "0") private int hits;
-    @ColumnDefault(value = "0") private int bookmarks;
-    @ColumnDefault(value = "0") private int reports;
+    @ColumnDefault(value = "0")
+    private int hits;
+    @ColumnDefault(value = "0")
+    private int bookmarks;
+    @ColumnDefault(value = "0")
+    private int reports;
 
 
     @OneToMany(fetch = FetchType.LAZY)
     private List<Image> image = new ArrayList<>();
 
 
-
-
-
-
     @ToString.Exclude
     @JoinColumn(name = "stu_id")
-    @ManyToOne(fetch = FetchType.LAZY )
+    @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
     /*
     TODO: 이미지 저장 필드 추후 개발
     */
 
-    public QnaBoard(){}
+    public QnaBoard() {
+    }
 
     public QnaBoard(User user, String title, String content, String tag, int point) {
         this.user = user;
@@ -60,31 +64,32 @@ public class QnaBoard extends AuditingFields{
 
     }
 
-    public QnaBoard(String title, String content,int point) {
+    public QnaBoard(String title, String content, int point) {
         this.title = title;
         this.content = content;
         this.point = point;
     }
 
     //추후 다른 곳에서(EX.. Test)에서 편하게 만들기위해 Factory method 사용
-    public static QnaBoard of(User user, String title, String content, String tag, int point){
-        return new QnaBoard(user,title,content,tag,point);
+    public static QnaBoard of(User user, String title, String content, String tag, int point) {
+        return new QnaBoard(user, title, content, tag, point);
     }
 
-    public static QnaBoard of(String title, String content,int point) {
-        return new QnaBoard(title,content,point);
+    public static QnaBoard of(String title, String content, int point) {
+        return new QnaBoard(title, content, point);
     }
 
-    public void updateBoard(QnaBoardDto dto){
-        if(dto.getTitle()!=null) this.title = dto.getTitle();
-        if(dto.getContent()!=null) this.content = dto.getContent();
+    public void updateBoard(QnaBoardDto dto) {
+        if (dto.getTitle() != null) this.title = dto.getTitle();
+        if (dto.getContent() != null) this.content = dto.getContent();
         this.tag = dto.getTag();
         this.point = dto.getPoint();
-    }
-    public void setUser(User user){
-        this.user = user;
+        modified();
     }
 
+    public void setUser(User user) {
+        this.user = user;
+    }
 
 
     @Override
@@ -92,7 +97,7 @@ public class QnaBoard extends AuditingFields{
         if (this == o) return true;
         if (!(o instanceof QnaBoard)) return false;
         QnaBoard that = (QnaBoard) o;
-        return id!=null && id.equals(that.id);
+        return id != null && id.equals(that.id);
     }
 
     @Override


### PR DESCRIPTION
- 조회수 기능 추가로 발생한 수정 시간 필드의 변경 문제 해결
- ModifiedEntity로 수정 시간 필드 분리 후 FreeBoard, QnaBoard Entity의 수정 로직에 적용
- 추후, 댓글 관련 Entity에도 적용 가능