### PR TITLE
구인게시판 구현(초안) 관련 PR입니다.

### DIFF
--- a/src/main/java/com/hansung/hansungcommunity/controller/RecruitBoardController.java
+++ b/src/main/java/com/hansung/hansungcommunity/controller/RecruitBoardController.java
@@ -1,0 +1,32 @@
+package com.hansung.hansungcommunity.controller;
+
+import com.hansung.hansungcommunity.auth.CustomAuthentication;
+import com.hansung.hansungcommunity.dto.RecruitBoardRequestDto;
+import com.hansung.hansungcommunity.service.RecruitBoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class RecruitBoardController {
+
+    private final RecruitBoardService recruitBoardService;
+
+    /**
+     * 게시글 생성
+     */
+    @PostMapping("/recruit-board")
+    public ResponseEntity<Long> create(@RequestBody RecruitBoardRequestDto dto, Authentication authentication) {
+        CustomAuthentication ca = (CustomAuthentication) authentication;
+        Long savedId = recruitBoardService.post(ca.getUser().getId(), dto);
+
+        return ResponseEntity.ok(savedId);
+    }
+
+}

--- a/src/main/java/com/hansung/hansungcommunity/dto/RecruitBoardRequestDto.java
+++ b/src/main/java/com/hansung/hansungcommunity/dto/RecruitBoardRequestDto.java
@@ -1,0 +1,16 @@
+package com.hansung.hansungcommunity.dto;
+
+import lombok.Data;
+
+/**
+ * 구인 게시글 생성 요청 DTO
+ * 추후 필드 추가 등 작업 요망
+ */
+
+@Data
+public class RecruitBoardRequestDto {
+
+    private String title;
+    private String content;
+
+}

--- a/src/main/java/com/hansung/hansungcommunity/entity/Party.java
+++ b/src/main/java/com/hansung/hansungcommunity/entity/Party.java
@@ -1,0 +1,25 @@
+package com.hansung.hansungcommunity.entity;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+
+/**
+ * 팀과 유저 간 다대다 관계를 풀기 위한
+ * 구인 게시글 관련 엔티티
+ */
+
+@Entity
+@Getter
+public class Party {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+    @ManyToOne
+    @JoinColumn(name = "recruit_board_id")
+    private RecruitBoard recruitBoard;
+
+}

--- a/src/main/java/com/hansung/hansungcommunity/entity/RecruitBoard.java
+++ b/src/main/java/com/hansung/hansungcommunity/entity/RecruitBoard.java
@@ -1,0 +1,77 @@
+package com.hansung.hansungcommunity.entity;
+
+import com.hansung.hansungcommunity.dto.RecruitBoardRequestDto;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Table(name = "recruit_board")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class RecruitBoard extends ModifiedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recruit_board_id")
+    private Long id;
+    private String title;
+    private String content;
+    @ColumnDefault(value = "0")
+    private int hits;
+    @ColumnDefault(value = "0")
+    private int bookmarks;
+    @ColumnDefault(value = "0")
+    private int reports;
+    private int party; // 모집할 인원 수
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stu_id")
+    private User user;
+
+    @OneToMany(mappedBy = "recruitBoard")
+    private List<Party> parties = new ArrayList<>();
+
+    // 테스트용, 추후 인자 추가 등 작업 요망
+    private RecruitBoard(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public static RecruitBoard createBoard(RecruitBoardRequestDto dto, User user) {
+        RecruitBoard board = new RecruitBoard(
+                dto.getTitle(),
+                dto.getContent()
+        );
+        board.setUser(user);
+
+        return board;
+    }
+
+    // 연관관계 메소드
+    public void setUser(User user) {
+        this.user = user;
+        user.getPostRecruitBoards().add(this);
+    }
+
+//    public void patch(RecruitBoardDto dto) {
+//        if (dto.getTitle() != null)
+//            this.title = dto.getTitle();
+//
+//        if (dto.getContent() != null)
+//            this.content = dto.getContent();
+//
+//        modified();
+//    }
+
+    // 조회수 증가 메소드
+    public void increaseHits() {
+        this.hits++;
+    }
+
+}

--- a/src/main/java/com/hansung/hansungcommunity/entity/User.java
+++ b/src/main/java/com/hansung/hansungcommunity/entity/User.java
@@ -43,6 +43,12 @@ public class User {
     @OneToMany(mappedBy = "user")
     private List<QnaBoard> postQnaBoard = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user")
+    private List<RecruitBoard> postRecruitBoards = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Party> parties = new ArrayList<>();
+
     public User(String studentId, String name, String nickname, String introduce, String track1, String track2) {
         this.studentId = studentId;
         this.name = name;

--- a/src/main/java/com/hansung/hansungcommunity/repository/PartyRepository.java
+++ b/src/main/java/com/hansung/hansungcommunity/repository/PartyRepository.java
@@ -1,0 +1,8 @@
+package com.hansung.hansungcommunity.repository;
+
+import com.hansung.hansungcommunity.entity.Party;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PartyRepository extends JpaRepository<Party, Long> {
+
+}

--- a/src/main/java/com/hansung/hansungcommunity/repository/RecruitBoardRepository.java
+++ b/src/main/java/com/hansung/hansungcommunity/repository/RecruitBoardRepository.java
@@ -1,0 +1,8 @@
+package com.hansung.hansungcommunity.repository;
+
+import com.hansung.hansungcommunity.entity.RecruitBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecruitBoardRepository extends JpaRepository<RecruitBoard, Long> {
+
+}

--- a/src/main/java/com/hansung/hansungcommunity/service/RecruitBoardService.java
+++ b/src/main/java/com/hansung/hansungcommunity/service/RecruitBoardService.java
@@ -1,0 +1,31 @@
+package com.hansung.hansungcommunity.service;
+
+import com.hansung.hansungcommunity.dto.RecruitBoardRequestDto;
+import com.hansung.hansungcommunity.entity.RecruitBoard;
+import com.hansung.hansungcommunity.entity.User;
+import com.hansung.hansungcommunity.repository.RecruitBoardRepository;
+import com.hansung.hansungcommunity.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecruitBoardService {
+
+    private final RecruitBoardRepository recruitBoardRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 게시글 저장
+     */
+    @Transactional
+    public Long post(Long userId, RecruitBoardRequestDto dto) {
+        User user = userRepository.getReferenceById(userId);
+        RecruitBoard saved = recruitBoardRepository.save(RecruitBoard.createBoard(dto, user));
+
+        return saved.getId();
+    }
+
+}


### PR DESCRIPTION
- 구인 게시글 엔티티 생성
- 구인 팀(Party) 엔티티 생성
- 유저 엔티티 수정
- 구인 게시글 관련 Controller, Service, Repository 생성
- 구인 게시글 생성 메소드 초안 구현 및 관련 DTO 생성

상단의 작업을 수행했습니다 !