### PR TITLE
구인 게시글 작성 및 목록, 상세 조회 연동 관련 PR입니다.

### DIFF
--- a/src/main/java/com/hansung/hansungcommunity/controller/RecruitBoardController.java
+++ b/src/main/java/com/hansung/hansungcommunity/controller/RecruitBoardController.java
@@ -21,7 +21,7 @@ public class RecruitBoardController {
     /**
      * 게시글 생성
      */
-    @PostMapping("/recruit-board")
+    @PostMapping("/recruit")
     public ResponseEntity<Long> create(@RequestBody RecruitBoardRequestDto dto, Authentication authentication) {
         CustomAuthentication ca = (CustomAuthentication) authentication;
         Long savedId = recruitBoardService.post(ca.getUser().getId(), dto);

--- a/src/main/java/com/hansung/hansungcommunity/controller/RecruitBoardController.java
+++ b/src/main/java/com/hansung/hansungcommunity/controller/RecruitBoardController.java
@@ -1,15 +1,20 @@
 package com.hansung.hansungcommunity.controller;
 
 import com.hansung.hansungcommunity.auth.CustomAuthentication;
+import com.hansung.hansungcommunity.dto.recruit.RecruitBoardDetailDto;
+import com.hansung.hansungcommunity.dto.recruit.RecruitBoardListDto;
 import com.hansung.hansungcommunity.dto.recruit.RecruitBoardRequestDto;
 import com.hansung.hansungcommunity.service.RecruitBoardService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,6 +32,63 @@ public class RecruitBoardController {
         Long savedId = recruitBoardService.post(ca.getUser().getId(), dto);
 
         return ResponseEntity.ok(savedId);
+    }
+
+    /**
+     * 게시글 목록 조회
+     */
+    @GetMapping("/recruit/list")
+    public ResponseEntity<List<RecruitBoardListDto>> list(Pageable pageable) {
+        List<RecruitBoardListDto> recruitList = recruitBoardService.getList(pageable);
+
+        return ResponseEntity.ok(recruitList);
+    }
+
+    /**
+     * 게시글 상세 조회
+     */
+    @GetMapping("/recruit/detail/{boardId}")
+    public ResponseEntity<RecruitBoardDetailDto> detail(
+            @PathVariable("boardId") Long boardId,
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        increaseHits(boardId, request, response);
+        RecruitBoardDetailDto detailDto = recruitBoardService.getDetail(boardId);
+
+        return ResponseEntity.ok(detailDto);
+    }
+
+    /**
+     * 조회수 증가 로직
+     */
+    private void increaseHits(Long boardId, HttpServletRequest request, HttpServletResponse response) {
+        Cookie oldCookie = null;
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("recruitBoardHits")) {
+                    oldCookie = cookie;
+                }
+            }
+        }
+
+        if (oldCookie != null) {
+            if (!oldCookie.getValue().contains("[" + boardId.toString() + "]")) {
+                recruitBoardService.increaseHits(boardId);
+                oldCookie.setValue(oldCookie.getValue() + "_[" + boardId + "]");
+                oldCookie.setPath("/");
+                oldCookie.setMaxAge(60 * 60 * 24);
+                response.addCookie(oldCookie);
+            }
+        } else {
+            recruitBoardService.increaseHits(boardId);
+            Cookie newCookie = new Cookie("recruitBoardHits", "[" + boardId + "]");
+            newCookie.setPath("/");
+            newCookie.setMaxAge(60 * 60 * 24);
+            response.addCookie(newCookie);
+        }
     }
 
 }

--- a/src/main/java/com/hansung/hansungcommunity/dto/recruit/RecruitBoardDetailDto.java
+++ b/src/main/java/com/hansung/hansungcommunity/dto/recruit/RecruitBoardDetailDto.java
@@ -1,0 +1,50 @@
+package com.hansung.hansungcommunity.dto.recruit;
+
+import com.hansung.hansungcommunity.entity.RecruitBoard;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecruitBoardDetailDto {
+
+    private Long id;
+    private String title;
+    private String content;
+    private String writer;
+    // private String profileImg;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+    private int bookmark;
+    // private int reply;
+    private int views;
+    private Long stuId;
+    // private List<String> imgUrl = new ArrayList<>();
+    private String require;
+    private String optional;
+    private int party;
+    private int gathered;
+
+    public static RecruitBoardDetailDto from(RecruitBoard recruitBoard) {
+        return new RecruitBoardDetailDto(
+                recruitBoard.getId(),
+                recruitBoard.getTitle(),
+                recruitBoard.getContent(),
+                recruitBoard.getUser().getNickname(),
+                recruitBoard.getCreatedAt(),
+                recruitBoard.getModifiedAt(),
+                recruitBoard.getBookmarks(),
+                recruitBoard.getHits(),
+                Long.parseLong(recruitBoard.getUser().getStudentId()),
+                recruitBoard.getRequired(),
+                recruitBoard.getOptional(),
+                recruitBoard.getParty(),
+                recruitBoard.getGathered()
+        );
+    }
+
+}

--- a/src/main/java/com/hansung/hansungcommunity/dto/recruit/RecruitBoardListDto.java
+++ b/src/main/java/com/hansung/hansungcommunity/dto/recruit/RecruitBoardListDto.java
@@ -1,0 +1,48 @@
+package com.hansung.hansungcommunity.dto.recruit;
+
+import com.hansung.hansungcommunity.entity.RecruitBoard;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class RecruitBoardListDto {
+
+    private Long id;
+    private String title;
+    private String writer;
+    // private String profileImg;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+    private int bookmark;
+    // private int reply;
+    private int views;
+    private Long stuId;
+    // private List<String> imgUrl = new ArrayList<>();
+    private String require;
+    private String optional;
+    private int party;
+    private int gathered;
+
+    public static RecruitBoardListDto from(RecruitBoard recruitBoard) {
+        return new RecruitBoardListDto(
+                recruitBoard.getId(),
+                recruitBoard.getTitle(),
+                recruitBoard.getUser().getNickname(),
+                recruitBoard.getCreatedAt(),
+                recruitBoard.getModifiedAt(),
+                recruitBoard.getBookmarks(),
+                recruitBoard.getHits(),
+                Long.parseLong(recruitBoard.getUser().getStudentId()),
+                recruitBoard.getRequired(),
+                recruitBoard.getOptional(),
+                recruitBoard.getParty(),
+                recruitBoard.getGathered()
+        );
+    }
+
+}

--- a/src/main/java/com/hansung/hansungcommunity/dto/recruit/RecruitBoardRequestDto.java
+++ b/src/main/java/com/hansung/hansungcommunity/dto/recruit/RecruitBoardRequestDto.java
@@ -12,5 +12,9 @@ public class RecruitBoardRequestDto {
 
     private String title;
     private String content;
+    private String required;
+    private String optional;
+    private int party;
+    private int gathered;
 
 }

--- a/src/main/java/com/hansung/hansungcommunity/entity/RecruitBoard.java
+++ b/src/main/java/com/hansung/hansungcommunity/entity/RecruitBoard.java
@@ -22,13 +22,14 @@ public class RecruitBoard extends ModifiedEntity {
     private Long id;
     private String title;
     private String content;
+    private String required;
+    private String optional;
     @ColumnDefault(value = "0")
     private int hits;
     @ColumnDefault(value = "0")
     private int bookmarks;
-    @ColumnDefault(value = "0")
-    private int reports;
     private int party; // 모집할 인원 수
+    private int gathered; // 모집된 인원 수
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "stu_id")
@@ -38,15 +39,23 @@ public class RecruitBoard extends ModifiedEntity {
     private List<Party> parties = new ArrayList<>();
 
     // 테스트용, 추후 인자 추가 등 작업 요망
-    private RecruitBoard(String title, String content) {
+    private RecruitBoard(String title, String content, String required, String optional, int party, int gathered) {
         this.title = title;
         this.content = content;
+        this.required = required;
+        this.optional = optional;
+        this.party = party;
+        this.gathered = gathered;
     }
 
     public static RecruitBoard createBoard(RecruitBoardRequestDto dto, User user) {
         RecruitBoard board = new RecruitBoard(
                 dto.getTitle(),
-                dto.getContent()
+                dto.getContent(),
+                dto.getRequired(),
+                dto.getOptional(),
+                dto.getParty(),
+                dto.getGathered()
         );
         board.setUser(user);
 

--- a/src/main/java/com/hansung/hansungcommunity/service/RecruitBoardService.java
+++ b/src/main/java/com/hansung/hansungcommunity/service/RecruitBoardService.java
@@ -1,13 +1,21 @@
 package com.hansung.hansungcommunity.service;
 
+import com.hansung.hansungcommunity.dto.recruit.RecruitBoardDetailDto;
+import com.hansung.hansungcommunity.dto.recruit.RecruitBoardListDto;
 import com.hansung.hansungcommunity.dto.recruit.RecruitBoardRequestDto;
 import com.hansung.hansungcommunity.entity.RecruitBoard;
 import com.hansung.hansungcommunity.entity.User;
 import com.hansung.hansungcommunity.repository.RecruitBoardRepository;
 import com.hansung.hansungcommunity.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +34,32 @@ public class RecruitBoardService {
         RecruitBoard saved = recruitBoardRepository.save(RecruitBoard.createBoard(dto, user));
 
         return saved.getId();
+    }
+
+    public List<RecruitBoardListDto> getList(Pageable pageable) {
+        Pageable setPage = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.Direction.DESC, "createdAt");
+        return recruitBoardRepository.findAll(setPage).getContent()
+                .stream()
+                .map(RecruitBoardListDto::from)
+                .collect(Collectors.toList());
+    }
+
+    public RecruitBoardDetailDto getDetail(Long boardId) {
+        RecruitBoard recruitBoard = recruitBoardRepository.findById(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 구인 게시글이 없습니다."));
+
+        return RecruitBoardDetailDto.from(recruitBoard);
+    }
+
+    /**
+     * 조회수 증가 로직
+     */
+    @Transactional
+    public void increaseHits(Long boardId) {
+        RecruitBoard board = recruitBoardRepository.findById(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("조회수 증가 실패, 해당하는 게시글이 없음"));
+
+        board.increaseHits();
     }
 
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,6 +1,6 @@
-INSERT INTO user (stu_id, name, nickname, point, student_id,career, introduce)
-VALUES (100, 'USER1', 'NICK1', 0,'181234', '', ''),
-       (101, 'USER2', 'NICK2', 0, '185678','', '');
+INSERT INTO user (stu_id, name, nickname, point, student_id, career, introduce)
+VALUES (100, 'USER1', 'NICK1', 0, '181234', '', ''),
+       (101, 'USER2', 'NICK2', 0, '185678', '', '');
 
 INSERT INTO free_board (free_board_id, title, content, stu_id, created_at)
 VALUES (100, 'Test title 1', 'Test content 1', 100, '2023-02-07 18:41:40.000000'),
@@ -14,13 +14,21 @@ VALUES (100, 'Test title 1', 'Test content 1', 100, '2023-02-07 18:41:40.000000'
        (108, 'Test title 9', 'Test content 9', 101, '2023-02-10 18:46:40.000000'),
        (109, 'Test title 10', 'Test content 10', 100, '2023-02-10 19:47:40.000000');
 
+INSERT INTO qna_board (stu_id, title, content, tag, point, created_at, language)
+VALUES (100, 'hi1', 'content', '#spring', 10, '2023-02-07 18:47:40.000000', 'java'),
+       (100, 'hi2', 'content', '#spring', 15, '2023-02-08 12:48:40.000000', 'c'),
+       (100, 'hi3', 'content', '#spring', 15, '2023-02-08 18:49:40.000000', 'c'),
+       (100, 'hi4', 'content', '#spring', 15, '2023-02-08 22:59:40.000000', 'java');
 
-
-
-
-INSERT INTO qna_board (stu_id, title, content, tag, point, created_at,language) values
-    (100, 'hi1', 'content', '#spring', 10, '2023-02-07 18:47:40.000000','java'),
-    (100, 'hi2','content','#spring',15,'2023-02-08 12:48:40.000000','c'),
-    (100, 'hi3','content','#spring',15,'2023-02-08 18:49:40.000000','c'),
-    (100, 'hi4','content','#spring',15,'2023-02-08 22:59:40.000000','java');
-
+INSERT INTO recruit_board (recruit_board_id, title, content, created_at, modified_at, bookmarks, stu_id, required,
+                           optional, party, gathered)
+VALUES (1, '게임 개발 공모전 같이 나가실 분을 구합니다.', '쉽지 않은 인생입니다.', '2023-03-18', NULL, 1, 100, '게임개발에 대한 열정이 넘치시는 분!',
+        '유니티 사용 경험이 있으시다면 더욱 좋겠습니다!', 6, 3),
+       (2, '캡스톤 팀원 구합니다아아앙 [한명만 더!!]', '하나하나 차근차근', '2023-03-14', '2023-03-20', 0, 100, '프랩 A이신분', NULL, 3, 1),
+       (3, '10학번이랑 팀플 같이 할 사람', '해내다 보면 언젠가는', '2023-03-14', NULL, 1, 100, '데베설 B분반', '깃허브 사용해본 경험 있으신 분', 4, 2),
+       (4, '재앙 가논 잡으러 갈 하이랄의 용사를 구합니다', '성취할 날이 올겁니다.', '2023-03-22', NULL, 0, 101, '마스터소드를 뽑아보신 분',
+        '신체 건강하고 해외여행결격사유가 없으신 분', 2, 1),
+       (5, '네프네프네프네프', '그러니 우리 마지막까지 힘내서', '2022-02-22', NULL, 7, 100, '네프 C반! 학점 4.0 이상!!', '2학년 자바프로젝트 보여주셔야합니다.', 2,
+        1),
+       (6, '디자인띵킹 팀원 구해봅니다 [한명만 더!!]', '한 학기 잘 마무리해봐요 !!!', '2023-03-10', '2023-03-11', 0, 101, '디띵 C분반!!!', NULL, 3,
+        1);


### PR DESCRIPTION
다음의 작업을 수행했습니다.
- 구인 게시글 작성 요청 관련 API 구현
- 구인 게시판 목록 조회 관련 API 구현
- 구인 게시판 상세 조회 관련 API 구현
- 조회수 로직 구현
- 구인 게시글 더미 데이터 생성을 위해 data.sql 파일 수정