### PR TITLE
조회수 기준 게시글 조회 기능 관련 PR입니다.

### DIFF
--- a/src/main/java/com/hansung/hansungcommunity/controller/BoardController.java
+++ b/src/main/java/com/hansung/hansungcommunity/controller/BoardController.java
@@ -1,0 +1,31 @@
+package com.hansung.hansungcommunity.controller;
+
+import com.hansung.hansungcommunity.dto.BoardMainDto;
+import com.hansung.hansungcommunity.service.BoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class BoardController {
+
+    private final BoardService boardService;
+
+    /**
+     * 인기 게시글 반환
+     * 조회수를 기준으로 5개의 게시글 반환
+     */
+    @GetMapping("/popular")
+    public ResponseEntity<List<BoardMainDto>> getPopularBoards() {
+        List<BoardMainDto> boards = boardService.getPopularBoards();
+
+        return ResponseEntity.ok(boards);
+    }
+
+}

--- a/src/main/java/com/hansung/hansungcommunity/dto/BoardMainDto.java
+++ b/src/main/java/com/hansung/hansungcommunity/dto/BoardMainDto.java
@@ -1,0 +1,39 @@
+package com.hansung.hansungcommunity.dto;
+
+import com.hansung.hansungcommunity.entity.Board;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 메인 페이지 인기 게시글 조회 DTO
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BoardMainDto {
+
+    private Long id;
+    private String title;
+    private String boardType;
+
+    public static BoardMainDto from(Board board) {
+        return new BoardMainDto(
+                board.getId(),
+                board.getTitle(),
+                typeConvert(board.getBoardType())
+        );
+    }
+
+    private static String typeConvert(String type) {
+        if (type.equals("FreeBoard")) {
+            return "free";
+        } else if (type.equals("QnaBoard")) {
+            return "qna";
+        } else {
+            return "recruit";
+        }
+    }
+
+}

--- a/src/main/java/com/hansung/hansungcommunity/dto/free/FreeBoardDetailsDto.java
+++ b/src/main/java/com/hansung/hansungcommunity/dto/free/FreeBoardDetailsDto.java
@@ -30,7 +30,7 @@ public class FreeBoardDetailsDto {
         this.modifiedDate = board.getModifiedAt();
         this.bookmark = board.getBookmarks().size();
         this.reply = board.getReplies().size();
-        this.views = board.getHits();
+        this.views = board.getViews();
     }
 
 }

--- a/src/main/java/com/hansung/hansungcommunity/dto/free/FreeBoardListDto.java
+++ b/src/main/java/com/hansung/hansungcommunity/dto/free/FreeBoardListDto.java
@@ -33,7 +33,7 @@ public class FreeBoardListDto {
         this.modifiedDate = board.getModifiedAt();
         this.bookmark = board.getBookmarks().size();
         this.reply = board.getReplies().size();
-        this.views = board.getHits();
+        this.views = board.getViews();
     }
 
 }

--- a/src/main/java/com/hansung/hansungcommunity/dto/qna/QnaBoardDetailsDto.java
+++ b/src/main/java/com/hansung/hansungcommunity/dto/qna/QnaBoardDetailsDto.java
@@ -31,7 +31,7 @@ public class QnaBoardDetailsDto {
         this.modifiedDate = board.getModifiedAt();
         this.language = board.getLanguage();
         this.bookmark = board.getBookmarks().size();
-        this.views = board.getHits();
+        this.views = board.getViews();
         this.reply = board.getReplies().size();
         this.point = board.getPoint();
     }

--- a/src/main/java/com/hansung/hansungcommunity/dto/recruit/RecruitBoardDetailDto.java
+++ b/src/main/java/com/hansung/hansungcommunity/dto/recruit/RecruitBoardDetailDto.java
@@ -38,7 +38,7 @@ public class RecruitBoardDetailDto {
                 recruitBoard.getCreatedAt(),
                 recruitBoard.getModifiedAt(),
                 recruitBoard.getBookmarks(),
-                recruitBoard.getHits(),
+                recruitBoard.getViews(),
                 Long.parseLong(recruitBoard.getUser().getStudentId()),
                 recruitBoard.getRequired(),
                 recruitBoard.getOptional(),

--- a/src/main/java/com/hansung/hansungcommunity/dto/recruit/RecruitBoardListDto.java
+++ b/src/main/java/com/hansung/hansungcommunity/dto/recruit/RecruitBoardListDto.java
@@ -36,7 +36,7 @@ public class RecruitBoardListDto {
                 recruitBoard.getCreatedAt(),
                 recruitBoard.getModifiedAt(),
                 recruitBoard.getBookmarks(),
-                recruitBoard.getHits(),
+                recruitBoard.getViews(),
                 Long.parseLong(recruitBoard.getUser().getStudentId()),
                 recruitBoard.getRequired(),
                 recruitBoard.getOptional(),

--- a/src/main/java/com/hansung/hansungcommunity/entity/Board.java
+++ b/src/main/java/com/hansung/hansungcommunity/entity/Board.java
@@ -1,0 +1,31 @@
+package com.hansung.hansungcommunity.entity;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn
+public abstract class Board extends ModifiedEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private int views;
+
+    public void increaseViews() {
+        this.views++;
+    }
+
+    public String getBoardType() {
+        return this.getClass().getSimpleName(); // 게시글 타입은 엔티티 클래스의 이름(기본값)
+    }
+
+    /**
+     * 추상 메소드, 하위 엔티티(FreeBoard 등)의 getTitle() 메소드에 의해 오버라이딩
+     * 추후 공통 필드 리팩토링 시, 수정
+     */
+    public abstract String getTitle();
+
+}

--- a/src/main/java/com/hansung/hansungcommunity/entity/FreeBoard.java
+++ b/src/main/java/com/hansung/hansungcommunity/entity/FreeBoard.java
@@ -3,7 +3,6 @@ package com.hansung.hansungcommunity.entity;
 import com.hansung.hansungcommunity.dto.free.FreeBoardRequestDto;
 import lombok.Getter;
 import lombok.Setter;
-import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -16,18 +15,14 @@ import java.util.Set;
 @Getter
 @Setter
 @Entity
-public class FreeBoard extends ModifiedEntity {
+public class FreeBoard extends Board {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "free_board_id")
     private Long id;
     @NotNull
     private String title; // 제목
     @NotNull
     private String content; // 내용
-    @ColumnDefault(value = "0")
-    private int hits; // 조회수
     @ManyToOne(fetch = FetchType.LAZY) // JPA 활용 시, XToOne 인 경우 fetch 타입을 LAZY 로 설정 !!!
     @JoinColumn(name = "stu_id")
     private User user;
@@ -66,9 +61,8 @@ public class FreeBoard extends ModifiedEntity {
         modified();
     }
 
-    // 조회수 증가 메소드
     public void increaseHits() {
-        this.hits++;
+        increaseViews();
     }
 
 }

--- a/src/main/java/com/hansung/hansungcommunity/entity/QnaBoard.java
+++ b/src/main/java/com/hansung/hansungcommunity/entity/QnaBoard.java
@@ -5,7 +5,6 @@ import com.hansung.hansungcommunity.dto.qna.QnaBoardRequestDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -15,11 +14,9 @@ import java.util.*;
 @ToString(callSuper = true)
 @Entity
 @NoArgsConstructor
-public class QnaBoard extends ModifiedEntity {
+public class QnaBoard extends Board {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "qna_board_id")
     private Long id;
     @NotNull
     private String title;
@@ -29,8 +26,6 @@ public class QnaBoard extends ModifiedEntity {
     private int point;
     @Column
     private String tag;
-    @ColumnDefault(value = "0")
-    private int hits;
     @Column
     private String language;
 
@@ -50,7 +45,7 @@ public class QnaBoard extends ModifiedEntity {
     private Set<QnaBoardBookmark> bookmarks = new HashSet<>();
 
     @OneToOne
-    @JoinColumn(name="adopt_id")
+    @JoinColumn(name = "adopt_id")
     private Adopt adopt;
 
     public QnaBoard(User user, String title, String content, String tag, int point, String language) {
@@ -107,7 +102,7 @@ public class QnaBoard extends ModifiedEntity {
 
     // 조회수 증가 메소드
     public void increaseHits() {
-        this.hits++;
+        increaseViews();
     }
 
 }

--- a/src/main/java/com/hansung/hansungcommunity/entity/RecruitBoard.java
+++ b/src/main/java/com/hansung/hansungcommunity/entity/RecruitBoard.java
@@ -14,18 +14,14 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class RecruitBoard extends ModifiedEntity {
+public class RecruitBoard extends Board {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "recruit_board_id")
     private Long id;
     private String title;
     private String content;
     private String required;
     private String optional;
-    @ColumnDefault(value = "0")
-    private int hits;
     @ColumnDefault(value = "0")
     private int bookmarks;
     private int party; // 모집할 인원 수
@@ -80,7 +76,7 @@ public class RecruitBoard extends ModifiedEntity {
 
     // 조회수 증가 메소드
     public void increaseHits() {
-        this.hits++;
+        increaseViews();
     }
 
 }

--- a/src/main/java/com/hansung/hansungcommunity/repository/BoardRepository.java
+++ b/src/main/java/com/hansung/hansungcommunity/repository/BoardRepository.java
@@ -1,0 +1,17 @@
+package com.hansung.hansungcommunity.repository;
+
+import com.hansung.hansungcommunity.entity.Board;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    @Query("SELECT b FROM Board b WHERE b.createdAt >= :standardTime ORDER BY b.views DESC")
+    List<Board> getPopularBoards(@Param("standardTime") LocalDateTime standardTime, Pageable pageable);
+
+}

--- a/src/main/java/com/hansung/hansungcommunity/repository/QnaBoardRepository.java
+++ b/src/main/java/com/hansung/hansungcommunity/repository/QnaBoardRepository.java
@@ -1,17 +1,22 @@
 package com.hansung.hansungcommunity.repository;
 
 import com.hansung.hansungcommunity.entity.QnaBoard;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 
 public interface QnaBoardRepository extends
-        JpaRepository<QnaBoard,Long>,
-        QuerydslPredicateExecutor<QnaBoard>{
+        JpaRepository<QnaBoard, Long>,
+        QuerydslPredicateExecutor<QnaBoard> {
 
     /*
     TODO: 추후 필요시 querydslBinderCustomizer 설정
      */
 
+    List<QnaBoard> findByCreatedAtAfter(LocalDateTime standardTime, Pageable pageable);
 
 }

--- a/src/main/java/com/hansung/hansungcommunity/service/BoardService.java
+++ b/src/main/java/com/hansung/hansungcommunity/service/BoardService.java
@@ -1,0 +1,27 @@
+package com.hansung.hansungcommunity.service;
+
+import com.hansung.hansungcommunity.dto.BoardMainDto;
+import com.hansung.hansungcommunity.entity.Board;
+import com.hansung.hansungcommunity.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+    private final BoardRepository boardRepository;
+
+    public List<BoardMainDto> getPopularBoards() {
+        LocalDateTime standardTime = LocalDateTime.now().minusWeeks(1); // 1주일 기준
+        List<Board> popularBoards = boardRepository.getPopularBoards(standardTime, PageRequest.of(0, 5)); // 상위 5개의 게시글
+
+        return popularBoards.stream().map(BoardMainDto::from).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/hansung/hansungcommunity/service/QnaBoardService.java
+++ b/src/main/java/com/hansung/hansungcommunity/service/QnaBoardService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -55,9 +56,10 @@ public class QnaBoardService {
      * 조회수를 기준으로 4개의 게시글 조회
      */
     public List<QnaBoardMostViewedDto> findMostViewedBoards() {
-        Pageable pageable = PageRequest.of(0,4, Sort.Direction.DESC,"hits");
+        Pageable pageable = PageRequest.of(0,4, Sort.Direction.DESC,"views");
+        LocalDateTime standardTime = LocalDateTime.now().minusWeeks(1); // 1주일 기준
 
-        return qnaBoardRepository.findAll(pageable).getContent()
+        return qnaBoardRepository.findByCreatedAtAfter(standardTime, pageable)
                 .stream()
                 .map(QnaBoardMostViewedDto::of)
                 .collect(Collectors.toList());

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,33 +2,55 @@ INSERT INTO user (stu_id, name, nickname, point, student_id, career, introduce)
 VALUES (100, 'USER1', 'NICK1', 0, '181234', '', ''),
        (101, 'USER2', 'NICK2', 0, '185678', '', '');
 
-INSERT INTO free_board (free_board_id, title, content, stu_id, created_at)
-VALUES (100, 'Test title 1', 'Test content 1', 100, '2023-02-07 18:41:40.000000'),
-       (101, 'Test title 2', 'Test content 2', 100, '2023-02-07 19:41:40.000000'),
-       (102, 'Test title 3', 'Test content 3', 101, '2023-02-08 15:41:40.000000'),
-       (103, 'Test title 4', 'Test content 4', 100, '2023-02-08 16:41:40.000000'),
-       (104, 'Test title 5', 'Test content 5', 101, '2023-02-08 19:41:40.000000'),
-       (105, 'Test title 6', 'Test content 6', 101, '2023-02-09 15:41:40.000000'),
-       (106, 'Test title 7', 'Test content 7', 101, '2023-02-09 16:41:40.000000'),
-       (107, 'Test title 8', 'Test content 8', 100, '2023-02-09 17:42:40.000000'),
-       (108, 'Test title 9', 'Test content 9', 101, '2023-02-10 18:46:40.000000'),
-       (109, 'Test title 10', 'Test content 10', 100, '2023-02-10 19:47:40.000000');
+INSERT INTO board (id, created_at, views, dtype)
+VALUES (1, '2023-04-28 18:41:40.000000', 0, 'FreeBoard'),
+       (2, '2023-04-28 18:41:40.000000', 1, 'FreeBoard'),
+       (3, '2023-04-28 18:41:40.000000', 2, 'FreeBoard'),
+       (4, '2023-04-28 18:41:40.000000', 3, 'FreeBoard'),
+       (5, '2023-04-28 18:41:40.000000', 4, 'FreeBoard'),
+       (6, '2023-04-28 18:41:40.000000', 5, 'FreeBoard'),
+       (7, '2023-04-28 18:41:40.000000', 6, 'FreeBoard'),
+       (8, '2023-04-28 18:41:40.000000', 0, 'FreeBoard'),
+       (9, '2023-04-28 18:41:40.000000', 4, 'FreeBoard'),
+       (10, '2023-04-28 18:41:40.000000', 2, 'FreeBoard'),
+       (11, '2023-04-28 18:41:40.000000', 0, 'QnaBoard'),
+       (12, '2023-04-28 18:41:40.000000', 0, 'QnaBoard'),
+       (13, '2023-04-28 18:41:40.000000', 7, 'QnaBoard'),
+       (14, '2023-04-28 18:41:40.000000', 0, 'QnaBoard'),
+       (15, '2023-04-28 18:41:40.000000', 8, 'RecruitBoard'),
+       (16, '2023-04-28 18:41:40.000000', 9, 'RecruitBoard'),
+       (17, '2023-04-28 18:41:40.000000', 10, 'RecruitBoard'),
+       (18, '2023-04-28 18:41:40.000000', 0, 'RecruitBoard'),
+       (19, '2023-04-28 18:41:40.000000', 2, 'RecruitBoard'),
+       (20, '2023-04-28 18:41:40.000000', 0, 'RecruitBoard');
 
-INSERT INTO qna_board (stu_id, title, content, tag, point, created_at, language)
-VALUES (100, 'hi1', 'content', '#spring', 10, '2023-02-07 18:47:40.000000', 'java'),
-       (100, 'hi2', 'content', '#spring', 15, '2023-02-08 12:48:40.000000', 'c'),
-       (100, 'hi3', 'content', '#spring', 15, '2023-02-08 18:49:40.000000', 'c'),
-       (100, 'hi4', 'content', '#spring', 15, '2023-02-08 22:59:40.000000', 'java');
+INSERT INTO free_board (id, title, content, stu_id)
+VALUES (1, 'Test title 1', 'Test content 1', 100),
+       (2, 'Test title 2', 'Test content 2', 100),
+       (3, 'Test title 3', 'Test content 3', 101),
+       (4, 'Test title 4', 'Test content 4', 100),
+       (5, 'Test title 5', 'Test content 5', 101),
+       (6, 'Test title 6', 'Test content 6', 101),
+       (7, 'Test title 7', 'Test content 7', 101),
+       (8, 'Test title 8', 'Test content 8', 100),
+       (9, 'Test title 9', 'Test content 9', 101),
+       (10, 'Test title 10', 'Test content 10', 100);
 
-INSERT INTO recruit_board (recruit_board_id, title, content, created_at, modified_at, bookmarks, stu_id, required,
+INSERT INTO qna_board (id, title, content, tag, point, language, stu_id)
+VALUES (11, 'hi1', 'content', '#spring', 10, 'java', 101),
+       (12, 'hi2', 'content', '#spring', 15, 'c', 101),
+       (13, 'hi3', 'content', '#spring', 15, 'c', 101),
+       (14, 'hi4', 'content', '#spring', 15, 'java', 101);
+
+INSERT INTO recruit_board (id, title, content, bookmarks, stu_id, required,
                            optional, party, gathered)
-VALUES (1, '게임 개발 공모전 같이 나가실 분을 구합니다.', '쉽지 않은 인생입니다.', '2023-03-18', NULL, 1, 100, '게임개발에 대한 열정이 넘치시는 분!',
+VALUES (15, '게임 개발 공모전 같이 나가실 분을 구합니다.', '쉽지 않은 인생입니다.', 1, 100, '게임개발에 대한 열정이 넘치시는 분!',
         '유니티 사용 경험이 있으시다면 더욱 좋겠습니다!', 6, 3),
-       (2, '캡스톤 팀원 구합니다아아앙 [한명만 더!!]', '하나하나 차근차근', '2023-03-14', '2023-03-20', 0, 100, '프랩 A이신분', NULL, 3, 1),
-       (3, '10학번이랑 팀플 같이 할 사람', '해내다 보면 언젠가는', '2023-03-14', NULL, 1, 100, '데베설 B분반', '깃허브 사용해본 경험 있으신 분', 4, 2),
-       (4, '재앙 가논 잡으러 갈 하이랄의 용사를 구합니다', '성취할 날이 올겁니다.', '2023-03-22', NULL, 0, 101, '마스터소드를 뽑아보신 분',
+       (16, '캡스톤 팀원 구합니다아아앙 [한명만 더!!]', '하나하나 차근차근', 0, 100, '프랩 A이신분', NULL, 3, 1),
+       (17, '10학번이랑 팀플 같이 할 사람', '해내다 보면 언젠가는', 1, 100, '데베설 B분반', '깃허브 사용해본 경험 있으신 분', 4, 2),
+       (18, '재앙 가논 잡으러 갈 하이랄의 용사를 구합니다', '성취할 날이 올겁니다.', 0, 101, '마스터소드를 뽑아보신 분',
         '신체 건강하고 해외여행결격사유가 없으신 분', 2, 1),
-       (5, '네프네프네프네프', '그러니 우리 마지막까지 힘내서', '2022-02-22', NULL, 7, 100, '네프 C반! 학점 4.0 이상!!', '2학년 자바프로젝트 보여주셔야합니다.', 2,
+       (19, '네프네프네프네프', '그러니 우리 마지막까지 힘내서', 7, 100, '네프 C반! 학점 4.0 이상!!', '2학년 자바프로젝트 보여주셔야합니다.', 2,
         1),
-       (6, '디자인띵킹 팀원 구해봅니다 [한명만 더!!]', '한 학기 잘 마무리해봐요 !!!', '2023-03-10', '2023-03-11', 0, 101, '디띵 C분반!!!', NULL, 3,
+       (20, '디자인띵킹 팀원 구해봅니다 [한명만 더!!]', '한 학기 잘 마무리해봐요 !!!', 0, 101, '디띵 C분반!!!', NULL, 3,
         1);


### PR DESCRIPTION
아래와 같은 작업을 수행했습니다.
- Board 엔티티 구현
- FreeBoard, QnaBoard, RecruitBoard가 Board 엔티티를 상속받도록 수정
- Board 엔티티에 조회수(views) 필드 생성
- 기존 조회수 관련 로직 수정(hits -> views)
- 1주일을 기준으로 상위 N개의 게시글을 반환하도록 구현 및 수정
- DB 구조의 변경에 따라 data.sql 수정