### PR TITLE
전체 게시글 수 응답 API 관련 PR입니다.

### DIFF
--- a/src/main/java/com/hansung/hansungcommunity/controller/FreeBoardApiController.java
+++ b/src/main/java/com/hansung/hansungcommunity/controller/FreeBoardApiController.java
@@ -113,6 +113,14 @@ public class FreeBoardApiController {
     }
 
     /**
+     * 전체 게시글 수
+     */
+    @GetMapping("/free/total")
+    public ResponseEntity<Long> getTotal() {
+        return ResponseEntity.ok(freeBoardService.getTotal());
+    }
+
+    /**
      * 조회수 증가 로직
      */
     private void increaseHits(Long boardId, HttpServletRequest request, HttpServletResponse response) {

--- a/src/main/java/com/hansung/hansungcommunity/controller/QnaBoardApiController.java
+++ b/src/main/java/com/hansung/hansungcommunity/controller/QnaBoardApiController.java
@@ -160,6 +160,14 @@ public class QnaBoardApiController {
     }
 
     /**
+     * 전체 게시글 수
+     */
+    @GetMapping("/questions/total")
+    public ResponseEntity<Long> getTotal() {
+        return ResponseEntity.ok(qnaBoardService.getTotal());
+    }
+
+    /**
      * 사진 url 전송 API
      */
     @PostMapping("/qna/image")

--- a/src/main/java/com/hansung/hansungcommunity/controller/RecruitBoardController.java
+++ b/src/main/java/com/hansung/hansungcommunity/controller/RecruitBoardController.java
@@ -56,6 +56,14 @@ public class RecruitBoardController {
     }
 
     /**
+     * 전체 게시글 수
+     */
+    @GetMapping("/recruit/total")
+    public ResponseEntity<Long> getTotal() {
+        return ResponseEntity.ok(recruitBoardService.getTotal());
+    }
+
+    /**
      * 게시글 목록 조회
      */
     @GetMapping("/recruit/list")

--- a/src/main/java/com/hansung/hansungcommunity/service/FreeBoardService.java
+++ b/src/main/java/com/hansung/hansungcommunity/service/FreeBoardService.java
@@ -122,5 +122,12 @@ public class FreeBoardService {
         return new FreeBoardUpdateDto(board);
     }
 
+    /**
+     * 전체 게시글 수
+     */
+    public long getTotal() {
+        return freeBoardRepository.count();
+    }
+
 }
 

--- a/src/main/java/com/hansung/hansungcommunity/service/QnaBoardService.java
+++ b/src/main/java/com/hansung/hansungcommunity/service/QnaBoardService.java
@@ -147,4 +147,11 @@ public class QnaBoardService {
         return new QnaBoardUpdateDto(board);
     }
 
+    /**
+     * 전체 게시글 수
+     */
+    public long getTotal() {
+        return qnaBoardRepository.count();
+    }
+
 }

--- a/src/main/java/com/hansung/hansungcommunity/service/RecruitBoardService.java
+++ b/src/main/java/com/hansung/hansungcommunity/service/RecruitBoardService.java
@@ -130,4 +130,11 @@ public class RecruitBoardService {
         recruitBoardRepository.deleteById(boardId);
     }
 
+    /**
+     * 전체 게시글 수
+     */
+    public long getTotal() {
+        return recruitBoardRepository.count();
+    }
+
 }


### PR DESCRIPTION
아래의 작업을 수행했습니다.
- 페이징 기능 개선을 위해 전체 게시글 수를 응답하는 API 구현 및 관련 비즈니스 로직 구현