### PR TITLE
마이페이지 유저 활동 수정 및 연동

### DIFF
--- a/src/main/java/com/hansung/hansungcommunity/dto/user/UserActivityDto.java
+++ b/src/main/java/com/hansung/hansungcommunity/dto/user/UserActivityDto.java
@@ -1,10 +1,12 @@
 package com.hansung.hansungcommunity.dto.user;
 
 import com.hansung.hansungcommunity.dto.BoardMainDto;
+import com.hansung.hansungcommunity.entity.Board;
 import com.hansung.hansungcommunity.entity.FreeBoard;
 import com.hansung.hansungcommunity.entity.QnaBoard;
 import com.hansung.hansungcommunity.entity.RecruitBoard;
 import lombok.Data;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
@@ -16,8 +18,8 @@ public class UserActivityDto {
     private String title;
     private String content;
     private LocalDateTime createdDate;
-
     private LocalDateTime modifiedDate;
+    private String writer ;
 
     private String language;
 
@@ -27,22 +29,24 @@ public class UserActivityDto {
 
     private String boardType;
 
-    public UserActivityDto(Long id, String title, String content, LocalDateTime createdAt, LocalDateTime modifiedAt, int bookmark, int reply,String boardType) {
+    public UserActivityDto(Long id, String title, String content, LocalDateTime createdAt, LocalDateTime modifiedAt,String writer, int bookmark, int reply, String boardType) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.createdDate = createdAt;
         this.modifiedDate = modifiedAt;
+        this.writer = writer;
         this.bookmark = bookmark;
         this.reply = reply;
         this.boardType = boardType;
     }
-    public UserActivityDto(Long id, String title, String content, LocalDateTime createdAt, LocalDateTime modifiedAt,String language, int bookmark, int reply,String boardType) {
+    public UserActivityDto(Long id, String title, String content, LocalDateTime createdAt, LocalDateTime modifiedAt,String writer,String language, int bookmark, int reply, String boardType) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.createdDate = createdAt;
         this.modifiedDate = modifiedAt;
+        this.writer = writer;
         this.language = language;
         this.bookmark = bookmark;
         this.reply = reply;
@@ -57,6 +61,7 @@ public class UserActivityDto {
                 freeBoard.getContent(),
                 freeBoard.getCreatedAt(),
                 freeBoard.getModifiedAt(),
+                freeBoard.getUser().getNickname(),
                 freeBoard.getBookmarks().size(),
                 freeBoard.getReplies().size(),
                 typeConvert(freeBoard.getBoardType())
@@ -70,6 +75,7 @@ public class UserActivityDto {
                 qnaBoard.getContent(),
                 qnaBoard.getCreatedAt(),
                 qnaBoard.getModifiedAt(),
+                qnaBoard.getUser().getNickname(),
                 qnaBoard.getLanguage(),
                 qnaBoard.getBookmarks().size(),
                 qnaBoard.getReplies().size(),
@@ -83,13 +89,12 @@ public class UserActivityDto {
                 recruitBoard.getContent(),
                 recruitBoard.getCreatedAt(),
                 recruitBoard.getModifiedAt(),
+                recruitBoard.getUser().getNickname(),
                 recruitBoard.getBookmarks().size(),
                 recruitBoard.getReplies().size(),
                 typeConvert(recruitBoard.getBoardType())
         );
     }
-
-
 
     private static String typeConvert(String type) {
         if (type.equals("FreeBoard")) {

--- a/src/main/java/com/hansung/hansungcommunity/repository/FreeReplyRepository.java
+++ b/src/main/java/com/hansung/hansungcommunity/repository/FreeReplyRepository.java
@@ -18,6 +18,7 @@ public interface FreeReplyRepository extends JpaRepository<FreeReply, Long>,
 
     Optional<List<FreeReply>> findAllByUserId(Long userId);
     Optional<FreeReply> findByFreeBoardId(Long userId);
+    List<FreeReply> findByUserId(Long userId);
 
 
 }

--- a/src/main/java/com/hansung/hansungcommunity/repository/QnaReplyRepository.java
+++ b/src/main/java/com/hansung/hansungcommunity/repository/QnaReplyRepository.java
@@ -20,4 +20,6 @@ public interface QnaReplyRepository extends JpaRepository<QnaReply, Long>,
     Optional<QnaReply> findByBoardId(Long boardId);
 
     QnaReply findFirstByBoardIdAndAdoptTrue(Long boardId);
+
+    List<QnaReply> findByUserId(Long userId);
 }

--- a/src/main/java/com/hansung/hansungcommunity/repository/RecruitReplyRepository.java
+++ b/src/main/java/com/hansung/hansungcommunity/repository/RecruitReplyRepository.java
@@ -20,4 +20,6 @@ public interface RecruitReplyRepository extends JpaRepository<RecruitReply,Long>
 
     Optional<List<RecruitReply>> findAllByUserId(Long userId);
     Optional<RecruitReply> findByRecruitBoardId(Long userId);
+
+    List<RecruitReply> findByUserId(Long userId);
 }

--- a/src/main/java/com/hansung/hansungcommunity/service/UserService.java
+++ b/src/main/java/com/hansung/hansungcommunity/service/UserService.java
@@ -27,6 +27,8 @@ public class UserService {
     private final QnaBoardBookmarkRepository qnaBoardBookmarkRepository;
     private final AdoptRepository adoptRepository;
     private final SkillRepository skillRepository;
+    private final MyPageService myPageService;
+
 
     /**
      * 회원가입
@@ -61,6 +63,9 @@ public class UserService {
     public UserInfoDto getUserInfo(Long stuId) {
        User user = userRepository.findById(stuId).orElseThrow(()->new IllegalArgumentException("유저가 존재하지 않습니다."));
         UserInfoDto userInfoDto = UserInfoDto.from(user);
+        userInfoDto.setReply(myPageService.getReplyList(stuId).size());
+        userInfoDto.setBoard(myPageService.getBoardList(stuId).size());
+        userInfoDto.setBookmark(myPageService.getBookmarkList(stuId).size());
         return userInfoDto;
     }
 


### PR DESCRIPTION
-  프론트 마이페이지에서 현재 접속 유저의 댓글을 단 게시글 수, 작성글 수, 북마크 게시글 수를 UserInfoDto로 받아오기에
 UserService에서 주도록 로직변경
- 오류 있던 MyPage API 수정