### PR TITLE
구인 게시글 API 추가 구현 관련 PR입니다.

### DIFF
--- a/src/main/java/com/hansung/hansungcommunity/controller/RecruitBoardController.java
+++ b/src/main/java/com/hansung/hansungcommunity/controller/RecruitBoardController.java
@@ -24,7 +24,6 @@ public class RecruitBoardController {
 
     private final RecruitBoardService recruitBoardService;
 
-
     /**
      * 메인페이지 리스트 조회
      */
@@ -142,6 +141,21 @@ public class RecruitBoardController {
     }
 
     /**
+     * 팀 소속 신청 승인 취소
+     */
+    @PutMapping("/recruit/{boardId}/disapproval/{targetUserId}")
+    public ResponseEntity<Boolean> disapprove(
+            @PathVariable("boardId") Long boardId,
+            @PathVariable("targetUserId") Long targetUserId,
+            Authentication authentication
+    ) {
+        CustomAuthentication ca = (CustomAuthentication) authentication;
+        boolean status = recruitBoardService.disapprove(boardId, ca.getUser().getId(), targetUserId);
+
+        return ResponseEntity.ok(status);
+    }
+
+    /**
      * 모집 완료
      */
     @PutMapping("/recruit/{boardId}/complete")
@@ -170,6 +184,16 @@ public class RecruitBoardController {
     @GetMapping("/recruit/{boardId}/applicants-number")
     public ResponseEntity<Long> getApplicantsNumber(@PathVariable("boardId") Long boardId) {
         Long number = recruitBoardService.getApplicantsNumber(boardId);
+
+        return ResponseEntity.ok(number);
+    }
+
+    /**
+     * 승인된 인원
+     */
+    @GetMapping("/recruit/{boardId}/approvers-number")
+    public ResponseEntity<Long> getApproversNumber(@PathVariable("boardId") Long boardId) {
+        Long number = recruitBoardService.getApproversNumber(boardId);
 
         return ResponseEntity.ok(number);
     }
@@ -212,6 +236,5 @@ public class RecruitBoardController {
     static class Result<T> {
         private T data;
     }
-
 
 }

--- a/src/main/java/com/hansung/hansungcommunity/dto/recruit/ApplicantDto.java
+++ b/src/main/java/com/hansung/hansungcommunity/dto/recruit/ApplicantDto.java
@@ -21,6 +21,7 @@ public class ApplicantDto {
     private Set<String> skills;
     private boolean isMeetRequired;
     private boolean isMeetOptional;
+    private boolean isApproved;
 
     public ApplicantDto(User user) {
         this.id = user.getId();

--- a/src/main/java/com/hansung/hansungcommunity/dto/recruit/RecruitBoardDetailDto.java
+++ b/src/main/java/com/hansung/hansungcommunity/dto/recruit/RecruitBoardDetailDto.java
@@ -28,8 +28,9 @@ public class RecruitBoardDetailDto {
     private String optional;
     private int party;
     private int gathered;
+    private boolean isCompleted;
 
-    private RecruitBoardDetailDto(Long id, String title, String content, String writer, String profileImg, LocalDateTime createdDate, LocalDateTime modifiedDate, int bookmark, int views, Long stuId, String require, String optional, int party) {
+    private RecruitBoardDetailDto(Long id, String title, String content, String writer, String profileImg, LocalDateTime createdDate, LocalDateTime modifiedDate, int bookmark, int views, Long stuId, String require, String optional, int party, boolean isCompleted) {
         this.id = id;
         this.title = title;
         this.content = content;
@@ -43,6 +44,7 @@ public class RecruitBoardDetailDto {
         this.require = require;
         this.optional = optional;
         this.party = party;
+        this.isCompleted = isCompleted;
     }
 
     public static RecruitBoardDetailDto from(RecruitBoard recruitBoard) {
@@ -59,7 +61,8 @@ public class RecruitBoardDetailDto {
                 Long.parseLong(recruitBoard.getUser().getStudentId()),
                 recruitBoard.getRequired(),
                 recruitBoard.getOptional(),
-                recruitBoard.getParty()
+                recruitBoard.getParty(),
+                recruitBoard.isCompleted()
         );
     }
 

--- a/src/main/java/com/hansung/hansungcommunity/dto/recruit/RecruitBoardListDto.java
+++ b/src/main/java/com/hansung/hansungcommunity/dto/recruit/RecruitBoardListDto.java
@@ -27,8 +27,9 @@ public class RecruitBoardListDto {
     private String optional;
     private int party;
     private int gathered;
+    private boolean isCompleted;
 
-    private RecruitBoardListDto(Long id, String title, String writer, String profileImg, LocalDateTime createdDate, LocalDateTime modifiedDate, int bookmark, int views, Long stuId, String require, String optional, int party) {
+    private RecruitBoardListDto(Long id, String title, String writer, String profileImg, LocalDateTime createdDate, LocalDateTime modifiedDate, int bookmark, int views, Long stuId, String require, String optional, int party, boolean isCompleted) {
         this.id = id;
         this.title = title;
         this.writer = writer;
@@ -41,6 +42,7 @@ public class RecruitBoardListDto {
         this.require = require;
         this.optional = optional;
         this.party = party;
+        this.isCompleted = isCompleted;
     }
 
     public static RecruitBoardListDto from(RecruitBoard recruitBoard) {
@@ -56,7 +58,8 @@ public class RecruitBoardListDto {
                 Long.parseLong(recruitBoard.getUser().getStudentId()),
                 recruitBoard.getRequired(),
                 recruitBoard.getOptional(),
-                recruitBoard.getParty()
+                recruitBoard.getParty(),
+                recruitBoard.isCompleted()
         );
     }
 

--- a/src/main/java/com/hansung/hansungcommunity/entity/Party.java
+++ b/src/main/java/com/hansung/hansungcommunity/entity/Party.java
@@ -46,4 +46,9 @@ public class Party extends AuditingFields {
         this.isApproved = true;
     }
 
+    // 승인 취소 처리
+    public void disapprove() {
+        this.isApproved = false;
+    }
+
 }

--- a/src/main/java/com/hansung/hansungcommunity/entity/RecruitBoard.java
+++ b/src/main/java/com/hansung/hansungcommunity/entity/RecruitBoard.java
@@ -73,9 +73,7 @@ public class RecruitBoard extends Board {
 
     // 자동 모집 완료 처리
     public void updateIsCompleted(Long count) {
-        if (this.gathered + count >= this.party) {
-            this.isCompleted = true;
-        }
+        this.isCompleted = this.gathered + count >= this.party;
     }
 
     public void patch(RecruitBoardRequestDto dto) {


### PR DESCRIPTION
아래와 같은 작업을 수행하였습니다.
- 구인 게시글 목록, 상세 API에 모집 마감 필드 추가를 위해 관련 DTO 수정
- 팀 소속 신청자 정보를 담는 DTO에 승인 여부 필드 추가
- 승인 취소 API 구현 및 관련 비즈니스 로직 구현
- 승인된 인원 수를 응답하는 API 구현