### PR TITLE
REFACTOR : #174 - 댓글 삭제 로직 리팩토링

### DIFF
--- a/src/main/java/com/hansung/hansungcommunity/repository/FreeReplyRepository.java
+++ b/src/main/java/com/hansung/hansungcommunity/repository/FreeReplyRepository.java
@@ -21,4 +21,6 @@ public interface FreeReplyRepository extends JpaRepository<FreeReply, Long>,
     List<FreeReply> findByUserId(Long userId);
 
 
+    List<FreeReply> findAllByParentId(Long id);
+
 }

--- a/src/main/java/com/hansung/hansungcommunity/repository/QnaReplyRepository.java
+++ b/src/main/java/com/hansung/hansungcommunity/repository/QnaReplyRepository.java
@@ -22,4 +22,6 @@ public interface QnaReplyRepository extends JpaRepository<QnaReply, Long>,
     QnaReply findFirstByBoardIdAndAdoptTrue(Long boardId);
 
     List<QnaReply> findByUserId(Long userId);
+
+    List<QnaReply> findAllByParentId(Long id);
 }

--- a/src/main/java/com/hansung/hansungcommunity/repository/RecruitReplyRepository.java
+++ b/src/main/java/com/hansung/hansungcommunity/repository/RecruitReplyRepository.java
@@ -2,6 +2,7 @@ package com.hansung.hansungcommunity.repository;
 
 
 import com.hansung.hansungcommunity.entity.FreeReply;
+import com.hansung.hansungcommunity.entity.QnaReply;
 import com.hansung.hansungcommunity.entity.RecruitReply;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -22,4 +23,6 @@ public interface RecruitReplyRepository extends JpaRepository<RecruitReply,Long>
     Optional<RecruitReply> findByRecruitBoardId(Long userId);
 
     List<RecruitReply> findByUserId(Long userId);
+
+    List<RecruitReply> findAllByParentId(Long id);
 }

--- a/src/main/java/com/hansung/hansungcommunity/service/FreeReplyService.java
+++ b/src/main/java/com/hansung/hansungcommunity/service/FreeReplyService.java
@@ -91,9 +91,20 @@ public class FreeReplyService {
 
     @Transactional
     public void delete(Long replyId) {
-        FreeReply reply = freeReplyRepository.findById(replyId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 댓글이 없습니다."));
-        freeReplyRepository.delete(reply);
+        deleteReplyMethod(replyId);
     }
 
+    //재귀 호출로 댓글의 대댓글 및 대댓글의 댓글 있을 시 모두 삭제
+    private void deleteReplyMethod(Long replyId) {
+        FreeReply reply = freeReplyRepository.findById(replyId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 댓글이 없습니다."));
+
+        // 댓글의 대댓글 삭제
+        List<FreeReply> children = freeReplyRepository.findAllByParentId(reply.getId());
+        for (FreeReply child : children) {
+            deleteReplyMethod(child.getId());
+        }
+        // 댓글 삭제
+        freeReplyRepository.delete(reply);
+    }
 }

--- a/src/main/java/com/hansung/hansungcommunity/service/QnaReplyService.java
+++ b/src/main/java/com/hansung/hansungcommunity/service/QnaReplyService.java
@@ -169,8 +169,19 @@ public class QnaReplyService {
 
     @Transactional
     public void delete(Long replyId) {
-        QnaReply qnaReply = replyRepository.findById(replyId)
-                .orElseThrow(()-> new IllegalArgumentException("해당 댓글이 없습니다."));
-        replyRepository.delete(qnaReply);
+        deleteReplyMethod(replyId);
     }
+
+    private void deleteReplyMethod(Long replyId){
+        QnaReply reply = replyRepository.findById(replyId)
+                .orElseThrow(()-> new IllegalArgumentException("해당 댓글이 없습니다."));
+        List<QnaReply> children = replyRepository.findAllByParentId(reply.getId());
+        for(QnaReply child : children){
+            deleteReplyMethod(child.getId());
+        }
+        replyRepository.delete(reply);
+    }
+
+
+
 }

--- a/src/main/java/com/hansung/hansungcommunity/service/RecruitReplyService.java
+++ b/src/main/java/com/hansung/hansungcommunity/service/RecruitReplyService.java
@@ -81,8 +81,16 @@ public class RecruitReplyService {
 
     @Transactional
     public void delete(Long replyId){
+        deleteReplyMethod(replyId);
+    }
+
+    private void deleteReplyMethod(Long replyId){
         RecruitReply reply = recruitReplyRepository.findById(replyId)
                 .orElseThrow(()-> new IllegalArgumentException("해당 댓글이 없습니다."));
+        List<RecruitReply> children = recruitReplyRepository.findAllByParentId(reply.getId());
+        for(RecruitReply child : children){
+            deleteReplyMethod(child.getId());
+        }
         recruitReplyRepository.delete(reply);
     }
 


### PR DESCRIPTION
- 현재 댓글 삭제 시, 
만약 댓글1의 대댓글2가 있고 대댓글2의 댓글3이 있고 댓글1의 댓글4 가 있는 여러 관계가 맺어진 댓글1을 삭제할 시 삭제 요청이 안됌.  
댓글1을 삭제 할 수 있도록 로직 변경